### PR TITLE
Fixes #1

### DIFF
--- a/admin/adminFunctions.php
+++ b/admin/adminFunctions.php
@@ -532,7 +532,7 @@ function selectTest(){
     $sql = "SELECT tGT.TestName, tG.GroupID
             FROM tblGroupTests tGT
             JOIN tblGroups tG on tGT.GroupID = tG.GroupID
-            WHERE tGT.TestName='".$_GET['selectTest']."'";
+            WHERE tGT.TestName='".$_GET['selectTest']."' AND tGT.Available=1";
 
     $qrySelectTests = mysqli_query($adminlink, $sql);
 


### PR DESCRIPTION
Simple enough.  In the original iteration groups were allocated using sql so classes that had not taken the test did not show up.  As it was developed every time a test is entered all groups are given the opportunity to take any test (think that was so it works for then being able to allocate a test to any class).